### PR TITLE
Make server port configurable

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -4,15 +4,36 @@ import (
 	"github.com/kabukky/httpscerts"
 	"log"
 	"net/http"
+  "flag"
+  "strings"
+  "fmt"
 )
 
+var port string
+
+func init() {
+  flag.StringVar(&port, "port", "1337", "Set the HTTP port")
+}
+
 func main() {
+  flag.Parse()
+
+  // Check if a port is set
+  if port != "" {
+    // Check if there is a colon (:) inside
+    index := strings.Index(port, ":")
+    // If not, prepend one
+    if index == -1 {
+      // Port needs to be in the format ":1234" so we prepand a ":"
+      port = ":" + port
+    }
+  }
 
 	// Check if the cert files are available.
 	err := httpscerts.Check("cert.pem", "key.pem")
 	// If they are not available, generate new ones.
 	if err != nil {
-		err = httpscerts.Generate("cert.pem", "key.pem", "127.0.0.1:1337")
+		err = httpscerts.Generate("cert.pem", "key.pem", fmt.Sprintf("127.0.0.1%s", port))
 		if err != nil {
 			log.Fatal("Error: Couldn't create https certs.")
 		}
@@ -23,5 +44,5 @@ func main() {
 	})
 
 	// HTTPS
-	log.Fatal(http.ListenAndServeTLS(":1337", "cert.pem", "key.pem", nil))
+	log.Fatal(http.ListenAndServeTLS(port, "cert.pem", "key.pem", nil))
 }

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,7 @@ import (
 var port string
 
 func init() {
-  flag.StringVar(&port, "port", "1337", "Set the HTTP port")
+  flag.StringVar(&port, "port", ":1337", "Set the HTTP port")
 }
 
 func main() {

--- a/server/main.go
+++ b/server/main.go
@@ -1,33 +1,33 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"github.com/kabukky/httpscerts"
 	"log"
 	"net/http"
-  "flag"
-  "strings"
-  "fmt"
+	"strings"
 )
 
 var port string
 
 func init() {
-  flag.StringVar(&port, "port", ":1337", "Set the HTTP port")
+	flag.StringVar(&port, "port", ":1337", "Set the HTTP port")
 }
 
 func main() {
-  flag.Parse()
+	flag.Parse()
 
-  // Check if a port is set
-  if port != "" {
-    // Check if there is a colon (:) inside
-    index := strings.Index(port, ":")
-    // If not, prepend one
-    if index == -1 {
-      // Port needs to be in the format ":1234" so we prepand a ":"
-      port = ":" + port
-    }
-  }
+	// Check if a port is set
+	if port != "" {
+		// Check if there is a colon (:) inside
+		index := strings.Index(port, ":")
+		// If not, prepend one
+		if index == -1 {
+			// Port needs to be in the format ":1234" so we prepand a ":"
+			port = ":" + port
+		}
+	}
 
 	// Check if the cert files are available.
 	err := httpscerts.Check("cert.pem", "key.pem")


### PR DESCRIPTION
This Pull Request adds a "-port" flag to the server program to allow setting a port. The default is still "1337" and the flag is optional. If no flag is provided the server will use port 1337.

The Cert & Key for SSL also use the new port. 